### PR TITLE
Adds helper functions to each node

### DIFF
--- a/kanonic-gen/src/main/kotlin/io/johnedquinn/kanonic/gen/impl/ClassNames.kt
+++ b/kanonic-gen/src/main/kotlin/io/johnedquinn/kanonic/gen/impl/ClassNames.kt
@@ -7,10 +7,13 @@ internal object ClassNames {
     val GRAMMAR = ClassName("io.johnedquinn.kanonic", "Grammar")
     val GRAMMAR_BUILDER_COMPANION = ClassName("io.johnedquinn.kanonic.dsl.GrammarBuilder", "Companion")
     val NODE = ClassName("io.johnedquinn.kanonic.parse", "Node")
+    val TERMINAL_NODE = ClassName("io.johnedquinn.kanonic.parse", "TerminalNode")
     val NODE_VISITOR = ClassName("io.johnedquinn.kanonic.parse", "NodeVisitor")
     val CREATE_NODE = ClassName("io.johnedquinn.kanonic.parse", "CreateNode")
     val PARSER_INFO = ClassName("io.johnedquinn.kanonic.parse", "ParserMetadata")
-    val LIST_NODE = ClassName("kotlin.collections", "List").parameterizedBy(NODE)
+    val LIST = ClassName("kotlin.collections", "List")
+    val LIST_TERMINAL_NODE = LIST.parameterizedBy(TERMINAL_NODE)
+    val LIST_NODE = LIST.parameterizedBy(NODE)
     val LIST_CREATE_NODE = ClassName("kotlin.collections", "List").parameterizedBy(CREATE_NODE)
 
     internal fun createGrammarNodeClass(packageName: String, grammarName: String) =


### PR DESCRIPTION
- Closes #8 

For single nodes, generated code looks like:
```
      public fun COLON_SEMI(): TerminalNode =
          this.children.filterIsInstance<io.johnedquinn.kanonic.parse.TerminalNode>().first {
        it.token.type == 5
      }
```

For multiple, looks like:
```
      public fun IDENT_CAMEL_CASE(): List<TerminalNode> =
          this.children.filterIsInstance<io.johnedquinn.kanonic.parse.TerminalNode>().filter {
        it.token.type == 3
      }
```